### PR TITLE
Fix typo

### DIFF
--- a/vignettes/development_and_debugging.Rmd
+++ b/vignettes/development_and_debugging.Rmd
@@ -27,7 +27,7 @@ The [RStudio v1.2 preview release](https://www.rstudio.com/rstudio/download/prev
 
 <img src="images/new_script.png" class="screenshot" width=600/>
 
-A simple template for a D3 script (the barchart.js example shown above) is provided by default. You can use the **Preview** command (Ctrl+Shift+Center) to render the visualization:
+A simple template for a D3 script (the barchart.js example shown above) is provided by default. You can use the **Preview** command (Ctrl+Shift+Enter) to render the visualization:
 
 <img src="images/rstudio_preview.png" class="screenshot" width=600/>
 


### PR DESCRIPTION
Fix typo in line 30: **Preview** shortcut is `Ctrl+Shift+Enter` (not `Center`)